### PR TITLE
Add admin_url variable parsing + conditional check for jwt logic

### DIFF
--- a/django_saml2_auth_multi/views.py
+++ b/django_saml2_auth_multi/views.py
@@ -134,7 +134,8 @@ def acs(request: HttpRequest):
     request.session.flush()
 
     use_jwt = dictor(saml2_auth_settings, "USE_JWT", False)
-    if use_jwt and target_user.is_active:
+    admin_url = dictor(saml2_auth_settings, "ADMIN_URL", "")
+    if use_jwt and target_user.is_active and next_url != admin_url:
         # Create a new JWT token for IdP-initiated login (acs)
         jwt_token = create_custom_or_default_jwt(target_user, request, saml2_auth_settings)
         custom_token_query_trigger = dictor(saml2_auth_settings, "TRIGGER.CUSTOM_TOKEN_QUERY")


### PR DESCRIPTION
This PR allows the package to parse a new variable in AUTH_CONFIG named "ADMIN_URL". It also updates the logic of `use_jwt` flag such that if the `next_url` i.e. the redirect URL is the `admin_url`, the JWT adjustments are not made as the django admin login does not use a JWT token.