### PR TITLE
bump pyjwt to 2.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "*"
 dictor = "==0.1.11"
-pyjwt = "==2.7.0"
+pyjwt = "==2.9.0"
 pysaml2 = "==7.4.2"
 setuptools = ">=67.8.0"
 


### PR DESCRIPTION
Upgrade [PyJWT](https://github.com/jpadilla/pyjwt/releases/tag/2.9.0) 2.9.0 to support Python 3.12